### PR TITLE
Add form duplicate, QC summary email export, and form notification co…

### DIFF
--- a/src/main/java/com/fps/svmes/controllers/FormNotificationConfigController.java
+++ b/src/main/java/com/fps/svmes/controllers/FormNotificationConfigController.java
@@ -1,0 +1,58 @@
+package com.fps.svmes.controllers;
+
+import com.fps.svmes.dto.dtos.notification.FormNotificationConfigDTO;
+import com.fps.svmes.dto.responses.ResponseResult;
+import com.fps.svmes.services.FormNotificationConfigService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+@RequestMapping("/form-notification-config")
+@RequiredArgsConstructor
+@Tag(name = "Form Notification Config API", description = "Per-form responsible person & email notification settings")
+public class FormNotificationConfigController {
+
+    private final FormNotificationConfigService service;
+
+    @GetMapping("")
+    @Operation(summary = "Get config by form template ID")
+    public ResponseResult<FormNotificationConfigDTO> getByFormTemplateId(@RequestParam Long formTemplateId) {
+        try {
+            FormNotificationConfigDTO dto = service.getByFormTemplateId(formTemplateId);
+            return ResponseResult.success(dto);
+        } catch (Exception e) {
+            log.error("Error fetching notification config for formTemplateId={}", formTemplateId, e);
+            return ResponseResult.fail("Error fetching notification config", e);
+        }
+    }
+
+    @PostMapping("")
+    @Operation(summary = "Create or update config (upsert)")
+    public ResponseResult<FormNotificationConfigDTO> save(@RequestBody FormNotificationConfigDTO dto) {
+        try {
+            FormNotificationConfigDTO saved = service.save(dto);
+            log.info("Notification config saved for formTemplateId={}", dto.getFormTemplateId());
+            return ResponseResult.success(saved);
+        } catch (Exception e) {
+            log.error("Error saving notification config", e);
+            return ResponseResult.fail("Error saving notification config", e);
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete config by ID")
+    public ResponseResult<Void> delete(@PathVariable Long id) {
+        try {
+            service.delete(id);
+            log.info("Notification config deleted, id={}", id);
+            return ResponseResult.success(null);
+        } catch (Exception e) {
+            log.error("Error deleting notification config id={}", id, e);
+            return ResponseResult.fail("Error deleting notification config", e);
+        }
+    }
+}

--- a/src/main/java/com/fps/svmes/controllers/QcFormDataController.java
+++ b/src/main/java/com/fps/svmes/controllers/QcFormDataController.java
@@ -49,6 +49,9 @@ public class QcFormDataController {
     @Autowired
     private QcSnapshotSubmissionService qcSnapshotSubmissionService;
 
+    @Autowired
+    private FormNotificationConfigService formNotificationConfigService;
+
     @PostMapping("/insert-form/{userId}/{collectionName}")
     public ResponseEntity<?> insertFormData(
             @PathVariable String collectionName,
@@ -117,6 +120,15 @@ public class QcFormDataController {
 
             // Evaluate control limits and trigger alerts if needed
             controlLimitEvaluationService.evaluateAndTriggerAlerts(formTemplateId, userId, formData, insertedDocument.getObjectId("_id").toString());
+
+            // Send notification emails to responsible persons (failure must not break submission)
+            try {
+                formNotificationConfigService.triggerSubmissionNotification(
+                        formTemplateId, userId, formData, exceededInfoMap,
+                        insertedDocument.getObjectId("_id").toString());
+            } catch (Exception notifEx) {
+                log.warn("Notification trigger failed for formTemplateId={}: {}", formTemplateId, notifEx.getMessage());
+            }
 
             // Prepare response
             Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/fps/svmes/controllers/QcFormTemplateController.java
+++ b/src/main/java/com/fps/svmes/controllers/QcFormTemplateController.java
@@ -3,6 +3,7 @@ package com.fps.svmes.controllers;
 
 import com.fps.svmes.dto.dtos.qcForm.QcFormTemplateDTO;
 import com.fps.svmes.dto.dtos.qcForm.QcFormTemplateEditLogDTO;
+import com.fps.svmes.dto.requests.DuplicateFormRequest;
 import com.fps.svmes.dto.requests.TemplateFormRequest;
 import com.fps.svmes.dto.responses.ResponseResult;
 import com.fps.svmes.models.sql.qcForm.QcFormTemplateEditLog;
@@ -171,6 +172,22 @@ public class QcFormTemplateController {
         } catch (Exception e) {
             log.error("Error updating template", e);
             return ResponseEntity.status(500).body("Error: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/{id}/duplicate")
+    @Operation(summary = "Duplicate a QC form template",
+            description = "Creates a copy of the template and places the new node in the same parent folder.")
+    public ResponseResult<Map<String, Object>> duplicateTemplate(
+            @PathVariable Long id,
+            @RequestBody DuplicateFormRequest request) {
+        try {
+            Map<String, Object> result = service.duplicateTemplate(id, request.getSourceNodeId(), request.getRequestedBy());
+            logger.info("Template {} duplicated, new id: {}", id, result.get("id"));
+            return ResponseResult.success(result);
+        } catch (Exception e) {
+            logger.error("Error duplicating template with ID: {}", id, e);
+            return ResponseResult.fail("Error duplicating template", e);
         }
     }
 

--- a/src/main/java/com/fps/svmes/controllers/QcSummaryEmailExportController.java
+++ b/src/main/java/com/fps/svmes/controllers/QcSummaryEmailExportController.java
@@ -1,0 +1,55 @@
+package com.fps.svmes.controllers;
+
+import com.fps.svmes.dto.requests.QcSummaryEmailExportRequest;
+import com.fps.svmes.dto.responses.QcSummaryEmailExportResponse;
+import com.fps.svmes.services.QcSummaryEmailExportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "QC Summary Email Export API", description = "API for exporting QC summary artifacts and sending them by email")
+public class QcSummaryEmailExportController {
+
+    private final QcSummaryEmailExportService qcSummaryEmailExportService;
+
+    @PostMapping("/export-send-email")
+    @Operation(summary = "Generate QC summary exports and send them by email")
+    public ResponseEntity<QcSummaryEmailExportResponse> exportSendEmail(
+            @Valid @RequestBody QcSummaryEmailExportRequest request,
+            @RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, required = false) String acceptLanguage) {
+        return ResponseEntity.ok(qcSummaryEmailExportService.exportAndSendEmail(request, acceptLanguage));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("message", exception.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, String>> handleUnreadableRequest(HttpMessageNotReadableException exception) {
+        return ResponseEntity.badRequest().body(Map.of("message", "Malformed request payload"));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException exception) {
+        log.error("Failed to export QC summary by email", exception);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("message", "Failed to export QC summary by email"));
+    }
+}

--- a/src/main/java/com/fps/svmes/dto/dtos/notification/FormNotificationConfigDTO.java
+++ b/src/main/java/com/fps/svmes/dto/dtos/notification/FormNotificationConfigDTO.java
@@ -1,0 +1,23 @@
+package com.fps.svmes.dto.dtos.notification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FormNotificationConfigDTO {
+
+    private Long id;
+
+    @JsonProperty("form_template_id")
+    private Long formTemplateId;
+
+    @JsonProperty("trigger_type")
+    private String triggerType = "always";
+
+    @JsonProperty("delivery_method")
+    private String deliveryMethod = "email";
+
+    private List<FormNotificationRecipientDTO> recipients;
+}

--- a/src/main/java/com/fps/svmes/dto/dtos/notification/FormNotificationRecipientDTO.java
+++ b/src/main/java/com/fps/svmes/dto/dtos/notification/FormNotificationRecipientDTO.java
@@ -1,0 +1,17 @@
+package com.fps.svmes.dto.dtos.notification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class FormNotificationRecipientDTO {
+
+    @JsonProperty("user_id")
+    private Integer userId;
+
+    @JsonProperty("user_email")
+    private String userEmail;
+
+    @JsonProperty("user_name")
+    private String userName;
+}

--- a/src/main/java/com/fps/svmes/dto/requests/DuplicateFormRequest.java
+++ b/src/main/java/com/fps/svmes/dto/requests/DuplicateFormRequest.java
@@ -1,0 +1,9 @@
+package com.fps.svmes.dto.requests;
+
+import lombok.Data;
+
+@Data
+public class DuplicateFormRequest {
+    private String sourceNodeId;
+    private Integer requestedBy;
+}

--- a/src/main/java/com/fps/svmes/dto/requests/QcSummaryEmailExportRequest.java
+++ b/src/main/java/com/fps/svmes/dto/requests/QcSummaryEmailExportRequest.java
@@ -1,0 +1,73 @@
+package com.fps.svmes.dto.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QcSummaryEmailExportRequest {
+
+    @NotBlank
+    @JsonProperty("start_date")
+    private String startDate;
+
+    @NotBlank
+    @JsonProperty("end_date")
+    private String endDate;
+
+    @JsonProperty("team_id")
+    private Integer teamId;
+
+    @JsonProperty("shift_id")
+    private Integer shiftId;
+
+    @JsonProperty("product_id")
+    private Integer productId;
+
+    @JsonProperty("batch_id")
+    private Integer batchId;
+
+    @JsonProperty("form_template_id")
+    private Long formTemplateId;
+
+    private String timezone = "UTC";
+
+    @NotEmpty
+    private List<@NotBlank @Email String> recipients;
+
+    @Valid
+    @NotNull
+    private Formats formats;
+
+    private Map<String, String> charts;
+
+    @AssertTrue(message = "At least one export format must be selected")
+    public boolean hasAnySelectedFormat() {
+        return formats != null && formats.hasAnySelected();
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Formats {
+        private boolean pdf;
+        private boolean excel;
+        private boolean ai;
+
+        public boolean hasAnySelected() {
+            return pdf || excel || ai;
+        }
+    }
+}

--- a/src/main/java/com/fps/svmes/dto/responses/QcSummaryEmailExportResponse.java
+++ b/src/main/java/com/fps/svmes/dto/responses/QcSummaryEmailExportResponse.java
@@ -1,0 +1,16 @@
+package com.fps.svmes.dto.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QcSummaryEmailExportResponse {
+    private String message;
+    private int recipientCount;
+    private List<String> attachmentNames;
+}

--- a/src/main/java/com/fps/svmes/models/sql/notification/FormNotificationConfig.java
+++ b/src/main/java/com/fps/svmes/models/sql/notification/FormNotificationConfig.java
@@ -1,0 +1,31 @@
+package com.fps.svmes.models.sql.notification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fps.svmes.models.sql.Common;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Entity
+@Table(name = "form_notification_config", schema = "quality_management")
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class FormNotificationConfig extends Common {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @JsonProperty("form_template_id")
+    @Column(name = "form_template_id", nullable = false, unique = true)
+    private Long formTemplateId;
+
+    @JsonProperty("trigger_type")
+    @Column(name = "trigger_type", nullable = false)
+    private String triggerType = "always";
+
+    @JsonProperty("delivery_method")
+    @Column(name = "delivery_method", nullable = false)
+    private String deliveryMethod = "email";
+}

--- a/src/main/java/com/fps/svmes/models/sql/notification/FormNotificationRecipient.java
+++ b/src/main/java/com/fps/svmes/models/sql/notification/FormNotificationRecipient.java
@@ -1,0 +1,47 @@
+package com.fps.svmes.models.sql.notification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "form_notification_recipient", schema = "quality_management")
+@Data
+public class FormNotificationRecipient {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @JsonProperty("config_id")
+    @Column(name = "config_id", nullable = false)
+    private Long configId;
+
+    @JsonProperty("user_id")
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @JsonProperty("user_email")
+    @Column(name = "user_email", nullable = false)
+    private String userEmail;
+
+    @JsonProperty("user_name")
+    @Column(name = "user_name")
+    private String userName;
+
+    @Column(name = "status")
+    private Integer status = 1;
+
+    @JsonProperty("created_at")
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) createdAt = OffsetDateTime.now();
+        if (status == null) status = 1;
+    }
+}

--- a/src/main/java/com/fps/svmes/repositories/jpaRepo/FormNotificationConfigRepository.java
+++ b/src/main/java/com/fps/svmes/repositories/jpaRepo/FormNotificationConfigRepository.java
@@ -1,0 +1,12 @@
+package com.fps.svmes.repositories.jpaRepo;
+
+import com.fps.svmes.models.sql.notification.FormNotificationConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FormNotificationConfigRepository extends JpaRepository<FormNotificationConfig, Long> {
+    Optional<FormNotificationConfig> findByFormTemplateId(Long formTemplateId);
+}

--- a/src/main/java/com/fps/svmes/repositories/jpaRepo/FormNotificationRecipientRepository.java
+++ b/src/main/java/com/fps/svmes/repositories/jpaRepo/FormNotificationRecipientRepository.java
@@ -1,0 +1,13 @@
+package com.fps.svmes.repositories.jpaRepo;
+
+import com.fps.svmes.models.sql.notification.FormNotificationRecipient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FormNotificationRecipientRepository extends JpaRepository<FormNotificationRecipient, Long> {
+    List<FormNotificationRecipient> findByConfigIdAndStatus(Long configId, Integer status);
+    void deleteByConfigId(Long configId);
+}

--- a/src/main/java/com/fps/svmes/services/EmailService.java
+++ b/src/main/java/com/fps/svmes/services/EmailService.java
@@ -1,8 +1,13 @@
 package com.fps.svmes.services;
 
+import java.util.List;
+import java.util.Map;
+
 public interface EmailService {
 
     void sendHtmlEmail(String to, String subject, String htmlContent);
+
+    void sendHtmlEmailWithAttachments(String to, List<String> bccRecipients, String subject, String htmlContent, Map<String, byte[]> attachments);
 
     void sendWeeklyReport(String to, String subject, String htmlContent);
 }

--- a/src/main/java/com/fps/svmes/services/FormNodeService.java
+++ b/src/main/java/com/fps/svmes/services/FormNodeService.java
@@ -16,4 +16,6 @@ public interface FormNodeService {
     boolean moveNode(String nodeId, String newParentId);
 
     void updateLabelByQcFormTemplateId(Long qcFormTemplateId, String newLabel);
+
+    Optional<String> findParentNodeId(String nodeId);
 }

--- a/src/main/java/com/fps/svmes/services/FormNotificationConfigService.java
+++ b/src/main/java/com/fps/svmes/services/FormNotificationConfigService.java
@@ -1,0 +1,20 @@
+package com.fps.svmes.services;
+
+import com.fps.svmes.dto.dtos.alert.ExceededFieldInfoDTO;
+import com.fps.svmes.dto.dtos.notification.FormNotificationConfigDTO;
+
+import java.util.Map;
+
+public interface FormNotificationConfigService {
+
+    FormNotificationConfigDTO getByFormTemplateId(Long formTemplateId);
+
+    FormNotificationConfigDTO save(FormNotificationConfigDTO dto);
+
+    void delete(Long configId);
+
+    void triggerSubmissionNotification(Long formTemplateId, Long submitterId,
+                                       Map<String, Object> formData,
+                                       Map<String, ExceededFieldInfoDTO> exceededInfo,
+                                       String submissionId);
+}

--- a/src/main/java/com/fps/svmes/services/QcFormTemplateService.java
+++ b/src/main/java/com/fps/svmes/services/QcFormTemplateService.java
@@ -7,6 +7,7 @@ import com.fps.svmes.dto.dtos.qcForm.QcFormTemplateDTO;
 import com.fps.svmes.dto.dtos.qcForm.QcFormTemplateEditLogDTO;
 
 import java.util.List;
+import java.util.Map;
 
 public interface QcFormTemplateService {
     List<QcFormTemplateDTO> getAllActiveTemplates();
@@ -22,4 +23,6 @@ public interface QcFormTemplateService {
     QcFormTemplateDTO updateTemplateWithNodeSync(Long id, QcFormTemplateDTO dto);
     List<QcFormTemplateEditLogDTO> getEditLog(Long templateId);
     List<java.util.Map<String, Object>> getTemplateFields(Long templateId);
+
+    Map<String, Object> duplicateTemplate(Long templateId, String sourceNodeId, Integer requestedBy);
 }

--- a/src/main/java/com/fps/svmes/services/QcSummaryEmailExportService.java
+++ b/src/main/java/com/fps/svmes/services/QcSummaryEmailExportService.java
@@ -1,0 +1,8 @@
+package com.fps.svmes.services;
+
+import com.fps.svmes.dto.requests.QcSummaryEmailExportRequest;
+import com.fps.svmes.dto.responses.QcSummaryEmailExportResponse;
+
+public interface QcSummaryEmailExportService {
+    QcSummaryEmailExportResponse exportAndSendEmail(QcSummaryEmailExportRequest request, String acceptLanguage);
+}

--- a/src/main/java/com/fps/svmes/services/QcTaskSubmissionLogsService.java
+++ b/src/main/java/com/fps/svmes/services/QcTaskSubmissionLogsService.java
@@ -17,6 +17,8 @@ public interface QcTaskSubmissionLogsService {
 
     byte[] exportDocumentsToExcel(List<Document> documents);
 
+    byte[] exportDocumentToExcel(Document document);
+
     byte[] exportDocumentToPdf(Document document);
 
     void deleteSubmissionLog(String submissionId, String collectionName);

--- a/src/main/java/com/fps/svmes/services/impl/EmailServiceImpl.java
+++ b/src/main/java/com/fps/svmes/services/impl/EmailServiceImpl.java
@@ -5,10 +5,14 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -22,17 +26,33 @@ public class EmailServiceImpl implements EmailService {
 
     @Override
     public void sendHtmlEmail(String to, String subject, String htmlContent) {
+        sendHtmlEmailWithAttachments(to, List.of(), subject, htmlContent, Map.of());
+    }
+
+    @Override
+    public void sendHtmlEmailWithAttachments(String to, List<String> bccRecipients, String subject, String htmlContent, Map<String, byte[]> attachments) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             helper.setFrom(fromEmail);
             helper.setTo(to);
+            if (bccRecipients != null && !bccRecipients.isEmpty()) {
+                helper.setBcc(bccRecipients.toArray(new String[0]));
+            }
             helper.setSubject(subject);
             helper.setText(htmlContent, true);
+            if (attachments != null && !attachments.isEmpty()) {
+                for (Map.Entry<String, byte[]> entry : attachments.entrySet()) {
+                    helper.addAttachment(entry.getKey(), new ByteArrayResource(entry.getValue()));
+                }
+            }
 
             mailSender.send(message);
-            log.info("Email sent successfully to: {}", to);
+            log.info("Email sent successfully to: {} (bccRecipients={}, attachments={})",
+                    to,
+                    bccRecipients == null ? 0 : bccRecipients.size(),
+                    attachments == null ? 0 : attachments.size());
         } catch (MessagingException e) {
             log.error("Failed to send email to: {}", to, e);
             throw new RuntimeException("Failed to send email", e);

--- a/src/main/java/com/fps/svmes/services/impl/FormNodeServiceImpl.java
+++ b/src/main/java/com/fps/svmes/services/impl/FormNodeServiceImpl.java
@@ -336,6 +336,27 @@ public class FormNodeServiceImpl implements FormNodeService {
         }
     }
 
+    @Override
+    public Optional<String> findParentNodeId(String nodeId) {
+        List<FormNode> roots = repository.findAll();
+        for (FormNode root : roots) {
+            if (root.getId().equals(nodeId)) return Optional.of("root");
+            Optional<String> parent = findParentRecursively(root, nodeId);
+            if (parent.isPresent()) return parent;
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> findParentRecursively(FormNode current, String targetId) {
+        if (current.getChildren() == null) return Optional.empty();
+        for (FormNode child : current.getChildren()) {
+            if (child.getId().equals(targetId)) return Optional.of(current.getId());
+            Optional<String> result = findParentRecursively(child, targetId);
+            if (result.isPresent()) return result;
+        }
+        return Optional.empty();
+    }
+
     private boolean updateLabelRecursive(FormNode node, Long templateId, String newLabel) {
         boolean updated = false;
         if (templateId.equals(node.getQcFormTemplateId())) {

--- a/src/main/java/com/fps/svmes/services/impl/FormNotificationConfigServiceImpl.java
+++ b/src/main/java/com/fps/svmes/services/impl/FormNotificationConfigServiceImpl.java
@@ -1,0 +1,584 @@
+package com.fps.svmes.services.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fps.svmes.dto.dtos.alert.ExceededFieldInfoDTO;
+import com.fps.svmes.dto.dtos.notification.FormNotificationConfigDTO;
+import com.fps.svmes.dto.dtos.notification.FormNotificationRecipientDTO;
+import com.fps.svmes.dto.dtos.qcForm.QcFormTemplateDTO;
+import com.fps.svmes.models.sql.notification.FormNotificationConfig;
+import com.fps.svmes.models.sql.notification.FormNotificationRecipient;
+import com.fps.svmes.repositories.jpaRepo.FormNotificationConfigRepository;
+import com.fps.svmes.repositories.jpaRepo.FormNotificationRecipientRepository;
+import com.fps.svmes.services.EmailService;
+import com.fps.svmes.services.FormNotificationConfigService;
+import com.fps.svmes.services.QcFormTemplateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FormNotificationConfigServiceImpl implements FormNotificationConfigService {
+
+    private final FormNotificationConfigRepository configRepo;
+    private final FormNotificationRecipientRepository recipientRepo;
+    private final EmailService emailService;
+    private final QcFormTemplateService qcFormTemplateService;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Set<String> EXCLUDED_KEYS = Set.of(
+            "e-signature", "exceeded_info", "approval_info",
+            "version_group_id", "version", "created_at", "created_by", "submitter_name"
+    );
+
+    private static final Map<String, List<String>> META_KEY_MAP = Map.of(
+            "product", List.of("related_products", "product", "product_name"),
+            "batch", List.of("related_batches", "batch", "batch_code"),
+            "shift", List.of("related_shifts", "belonging_shift", "shift"),
+            "team", List.of("related_teams", "belonging_team", "team"),
+            "inspector", List.of("related_inspectors", "qc_personnel", "inspector")
+    );
+
+    private static final Map<String, String> META_LABELS = Map.of(
+            "product", "PRODUCT",
+            "batch", "BATCH",
+            "shift", "SHIFT",
+            "team", "TEAM",
+            "inspector", "INSPECTOR"
+    );
+
+    // ─── Public API ──────────────────────────────────────────────────────────
+
+    @Override
+    public FormNotificationConfigDTO getByFormTemplateId(Long formTemplateId) {
+        Optional<FormNotificationConfig> opt = configRepo.findByFormTemplateId(formTemplateId);
+        if (opt.isEmpty()) return null;
+        FormNotificationConfig config = opt.get();
+        List<FormNotificationRecipient> recipients = recipientRepo.findByConfigIdAndStatus(config.getId(), 1);
+        return toDTO(config, recipients);
+    }
+
+    @Override
+    @Transactional
+    public FormNotificationConfigDTO save(FormNotificationConfigDTO dto) {
+        FormNotificationConfig config = configRepo.findByFormTemplateId(dto.getFormTemplateId())
+                .orElseGet(FormNotificationConfig::new);
+
+        config.setFormTemplateId(dto.getFormTemplateId());
+        config.setTriggerType(dto.getTriggerType() != null ? dto.getTriggerType() : "always");
+        config.setDeliveryMethod(dto.getDeliveryMethod() != null ? dto.getDeliveryMethod() : "email");
+        if (config.getId() == null) {
+            config.setCreationDetails(null, 1);
+        } else {
+            config.setUpdateDetails(null, 1);
+        }
+        config = configRepo.save(config);
+
+        recipientRepo.deleteByConfigId(config.getId());
+        final Long configId = config.getId();
+        if (dto.getRecipients() != null) {
+            List<FormNotificationRecipient> newRecipients = dto.getRecipients().stream()
+                    .map(r -> toEntity(r, configId))
+                    .collect(Collectors.toList());
+            recipientRepo.saveAll(newRecipients);
+        }
+
+        List<FormNotificationRecipient> saved = recipientRepo.findByConfigIdAndStatus(configId, 1);
+        return toDTO(config, saved);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long configId) {
+        recipientRepo.deleteByConfigId(configId);
+        configRepo.deleteById(configId);
+    }
+
+    @Override
+    public void triggerSubmissionNotification(Long formTemplateId, Long submitterId,
+                                              Map<String, Object> formData,
+                                              Map<String, ExceededFieldInfoDTO> exceededInfo,
+                                              String submissionId) {
+        try {
+            Optional<FormNotificationConfig> opt = configRepo.findByFormTemplateId(formTemplateId);
+            if (opt.isEmpty()) return;
+            FormNotificationConfig config = opt.get();
+
+            if ("on_alert".equals(config.getTriggerType()) && (exceededInfo == null || exceededInfo.isEmpty())) {
+                log.debug("Skipping notification for formTemplateId={}: on_alert trigger but no exceeded fields", formTemplateId);
+                return;
+            }
+
+            List<FormNotificationRecipient> recipients = recipientRepo.findByConfigIdAndStatus(config.getId(), 1);
+            if (recipients.isEmpty()) return;
+
+            String formName;
+            String formTemplateJson = null;
+            
+            log.debug("Triggering notification for submission={}. FormData keys: {}. TemplateJson exists: {}", 
+                    submissionId, formData != null ? formData.keySet() : "null", formTemplateJson != null);
+            try {
+                QcFormTemplateDTO template = qcFormTemplateService.getTemplateById(formTemplateId);
+                formName = template.getName();
+                formTemplateJson = template.getFormTemplateJson();
+            } catch (Exception e) {
+                formName = "Form #" + formTemplateId;
+            }
+
+            boolean hasAlerts = exceededInfo != null && !exceededInfo.isEmpty();
+            String subject = hasAlerts
+                    ? "[MES QC ⚠] " + formName + " — Submission with exceeded fields"
+                    : "[MES QC] " + formName + " — New submission";
+
+            String html = buildEmailHtml(formName, submissionId, submitterId,
+                    formData != null ? formData : Map.of(),
+                    exceededInfo != null ? exceededInfo : Map.of(),
+                    formTemplateJson);
+
+            for (FormNotificationRecipient recipient : recipients) {
+                try {
+                    emailService.sendHtmlEmail(recipient.getUserEmail(), subject, html);
+                    log.info("Notification sent to {} for formTemplateId={} submission={}",
+                            recipient.getUserEmail(), formTemplateId, submissionId);
+                } catch (Exception e) {
+                    log.error("Failed to send notification to {}: {}", recipient.getUserEmail(), e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error in triggerSubmissionNotification for formTemplateId={}: {}", formTemplateId, e.getMessage(), e);
+        }
+    }
+
+    // ─── Email HTML builders ──────────────────────────────────────────────────
+
+    private String buildEmailHtml(String formName, String submissionId, Long submitterId,
+                                   Map<String, Object> formData,
+                                   Map<String, ExceededFieldInfoDTO> exceededInfo,
+                                   String formTemplateJson) {
+        String timestamp = OffsetDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss xxx"));
+
+        return "<!DOCTYPE html><html><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width'></head>"
+                + "<body style='margin:0;padding:24px 16px;background:#f4f7f8;font-family:-apple-system,\"Helvetica Neue\",Arial,sans-serif;'>"
+                + "<table width='640' cellpadding='0' cellspacing='0' align='center' "
+                + "style='width:640px;max-width:100%;margin:0 auto;background:#fff;border-radius:6px;"
+                + "overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);'>"
+                + buildHeader(formName, submissionId, timestamp, !exceededInfo.isEmpty())
+                + buildContent(formData, exceededInfo, formTemplateJson)
+                + buildFooter(formData, submitterId, timestamp)
+                + "</table>"
+                + "</body></html>";
+    }
+
+    private String buildHeader(String formName, String submissionId, String timestamp, boolean hasAlerts) {
+        String alertBadge = hasAlerts
+                ? "<span style='display:inline-block;background:#fef2f2;color:#dc2626;padding:2px 8px;"
+                  + "border-radius:10px;font-size:11px;font-weight:600;margin-left:8px;vertical-align:middle;border:1px solid #fecaca;'>⚠ Alert</span>"
+                : "<span style='display:inline-block;background:#f0fdf4;color:#16a34a;padding:2px 8px;"
+                  + "border-radius:10px;font-size:11px;font-weight:600;margin-left:8px;vertical-align:middle;border:1px solid #bbf7d0;'>✓ Normal</span>";
+
+        return "<tr><td style='background:#ffffff;padding:24px 32px;border-bottom:1px solid #f0f4f6;'>"
+                + "<table width='100%' cellpadding='0' cellspacing='0'><tr>"
+                + "<td style='vertical-align:middle;'>"
+                + "<table cellpadding='0' cellspacing='0'><tr>"
+                + "<td style='vertical-align:middle;width:52px;height:52px;background:#0085a4;"
+                + "border-radius:50%;text-align:center;font-size:18px;font-weight:800;color:#fff;"
+                + "letter-spacing:1px;'>FPS</td>"
+                + "<td style='vertical-align:middle;padding-left:14px;'>"
+                + "<div style='font-size:18px;font-weight:700;color:#2c3e50;'>" + escHtml(formName) + alertBadge + "</div>"
+                + "<div style='font-size:11px;color:#7f8c8d;margin-top:4px;text-transform:uppercase;letter-spacing:0.5px;'>Quality Control Record</div>"
+                + "</td></tr></table>"
+                + "</td>"
+                + "<td style='text-align:right;vertical-align:middle;'>"
+                + "<div style='font-size:10px;color:#95a5a6;letter-spacing:0.5px;margin-bottom:5px;font-weight:700;'>RECORD NO.</div>"
+                + "<div style='display:inline-block;font-size:12px;font-weight:600;color:#0085a4;"
+                + "background:#e8f5f8;padding:2px 10px;border-radius:10px;'>" + escHtml(submissionId) + "</div>"
+                + "<div style='font-size:11px;color:#95a5a6;margin-top:6px;'>" + timestamp + "</div>"
+                + "</td>"
+                + "</tr></table>"
+                + "</td></tr>";
+    }
+
+    private String buildContent(Map<String, Object> formData, Map<String, ExceededFieldInfoDTO> exceededInfo,
+                                 String formTemplateJson) {
+        StringBuilder rows = new StringBuilder();
+        if (formTemplateJson != null && !formTemplateJson.isBlank()) {
+            try {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> template = OBJECT_MAPPER.readValue(formTemplateJson, Map.class);
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> widgetList = (List<Map<String, Object>>) template.get("widgetList");
+                traverseWidgets(widgetList, formData, exceededInfo, rows, new boolean[]{true});
+            } catch (Exception e) {
+                log.warn("Failed to parse formTemplateJson for email rendering, using flat list: {}", e.getMessage());
+                buildFlatFieldRows(formData, exceededInfo, rows);
+            }
+        } else {
+            buildFlatFieldRows(formData, exceededInfo, rows);
+        }
+
+        // Add Form Basic Fields section (before signature)
+        rows.append(buildBasicFields(formData));
+
+        // Signature section
+        Object signature = findValueRecursive(formData, "e-signature");
+        if (signature instanceof String sigStr && sigStr.startsWith("data:image")) {
+            rows.append("<tr><td colspan='2' style='padding-top:24px;'>")
+                .append("<div style='font-size:11px;color:#95a5a6;margin-bottom:8px;text-transform:uppercase;letter-spacing:0.5px;'>E-SIGNATURE</div>")
+                .append("<img src='").append(sigStr).append("' style='max-width:220px;height:auto;border:1px solid #dde8ed;border-radius:4px;' alt='signature'/>")
+                .append("</td></tr>");
+        }
+
+        return "<tr><td style='padding:20px 32px;'>"
+                + "<table width='100%' cellpadding='0' cellspacing='0' style='border-collapse:collapse;'>"
+                + rows
+                + "</table></td></tr>";
+    }
+
+    private String buildBasicFields(Map<String, Object> formData) {
+        StringBuilder sb = new StringBuilder();
+        boolean hasData = false;
+        
+        StringBuilder fieldRows = new StringBuilder();
+        for (String groupKey : List.of("product", "batch", "shift", "team", "inspector")) {
+            List<String> possibleKeys = META_KEY_MAP.get(groupKey);
+            Object val = null;
+            for (String key : possibleKeys) {
+                val = findValueRecursive(formData, key);
+                if (val != null && !val.toString().isBlank() && !"-".equals(val.toString())) {
+                    break; 
+                }
+            }
+            
+            if (val == null || val.toString().isBlank() || "-".equals(val.toString())) continue;
+            
+            String label = META_LABELS.getOrDefault(groupKey, groupKey.toUpperCase());
+            hasData = true;
+            
+            fieldRows.append("<tr>")
+              .append("<td style='width:50%;padding:8px 12px;border:1px solid #dde8ed;font-weight:600;color:#5a6a7a;font-size:12px;'>")
+              .append(escHtml(label))
+              .append("</td>")
+              .append("<td style='padding:8px 12px;border:1px solid #dde8ed;font-size:13px;color:#2c3e50;'>")
+              .append(escHtml(val.toString()))
+              .append("</td></tr>");
+        }
+        
+        if (hasData) {
+            sb.append("<tr><td colspan='2' style='height:32px; border:none;'></td></tr>");
+            sb.append("<tr><td colspan='2' style='padding:8px 0; border:none;'>")
+              .append("<div style='font-size:11px; color:#95a5a6; font-weight:700; text-transform:uppercase; letter-spacing:0.5px;'>Contextual Info</div>")
+              .append("</td></tr>");
+            sb.append(fieldRows);
+        }
+        
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void traverseWidgets(List<Map<String, Object>> widgetList, Map<String, Object> formData,
+                                  Map<String, ExceededFieldInfoDTO> exceededInfo, StringBuilder sb,
+                                  boolean[] firstBlock) {
+        if (widgetList == null) return;
+        for (Map<String, Object> widget : widgetList) {
+            Map<String, Object> options = (Map<String, Object>) widget.getOrDefault("options", Map.of());
+            String widgetType = String.valueOf(widget.getOrDefault("type", widget.getOrDefault("icon", "")));
+            String name = String.valueOf(options.getOrDefault("name", ""));
+            boolean formItemFlag = Boolean.TRUE.equals(widget.get("formItemFlag"));
+
+            if ("divider".equals(widgetType) && !formItemFlag) {
+                String text = (String) options.get("label");
+                if (text != null && !text.isBlank()) {
+                    if (!firstBlock[0]) {
+                        sb.append("<tr><td colspan='2' style='height:20px;padding:0;border:none;'></td></tr>");
+                    }
+                    firstBlock[0] = false;
+                    sb.append("<tr><td colspan='2' style='background:#0085a4;color:#fff;padding:8px 14px;"
+                            + "font-size:13px;font-weight:700;letter-spacing:0.5px;border:1px solid #006f8a;'>")
+                      .append(escHtml(text)).append("</td></tr>");
+                }
+            } else if (name.startsWith("static-text") && !formItemFlag) {
+                String textContent = (String) options.get("textContent");
+                if (textContent != null) {
+                    String stripped = textContent.replaceAll("<[^>]+>", "").trim();
+                    if (!stripped.isBlank()) {
+                        sb.append("<tr><td colspan='2' style='background:#e8f5f8;padding:6px 14px;"
+                                + "font-size:11px;font-weight:600;color:#4a8a99;font-style:italic;"
+                                + "border:1px solid #dde8ed;border-left:3px solid #b2dce6;'>")
+                          .append(escHtml(stripped)).append("</td></tr>");
+                    }
+                }
+            } else if (formItemFlag) {
+                String label = (String) options.get("label");
+                String widgetName = (String) options.get("name");
+                
+                Object value = null;
+                if (widgetName != null) value = findValueRecursive(formData, widgetName);
+                if (value == null && label != null) value = findValueRecursive(formData, label);
+
+                if (value != null && !"e-signature".equalsIgnoreCase(label) && !"e-signature".equalsIgnoreCase(widgetName)) {
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> optionItems = (List<Map<String, Object>>) options.get("optionItems");
+                    if (optionItems == null) {
+                        @SuppressWarnings("unchecked")
+                        List<Map<String, Object>> altOptions = (List<Map<String, Object>>) options.get("options");
+                        optionItems = altOptions;
+                    }
+                    appendFieldRow(sb, label, widgetName, value, exceededInfo, optionItems);
+                }
+            }
+
+            // Recurse into container widgets
+            List<Map<String, Object>> cols = (List<Map<String, Object>>) widget.get("cols");
+            if (cols != null) {
+                for (Map<String, Object> col : cols)
+                    traverseWidgets((List<Map<String, Object>>) col.get("widgetList"), formData, exceededInfo, sb, firstBlock);
+            }
+            List<Map<String, Object>> rowsList = (List<Map<String, Object>>) widget.get("rows");
+            if (rowsList != null) {
+                for (Map<String, Object> row : rowsList) {
+                    List<Map<String, Object>> rowCols = (List<Map<String, Object>>) row.get("cols");
+                    if (rowCols != null)
+                        for (Map<String, Object> col : rowCols)
+                            traverseWidgets((List<Map<String, Object>>) col.get("widgetList"), formData, exceededInfo, sb, firstBlock);
+                }
+            }
+            List<Map<String, Object>> tabs = (List<Map<String, Object>>) widget.get("tabs");
+            if (tabs != null) {
+                for (Map<String, Object> tab : tabs)
+                    traverseWidgets((List<Map<String, Object>>) tab.get("widgetList"), formData, exceededInfo, sb, firstBlock);
+            }
+            // Generic nested widgetList (only if no other container matched)
+            if (cols == null && rowsList == null && tabs == null) {
+                List<Map<String, Object>> nested = (List<Map<String, Object>>) widget.get("widgetList");
+                if (nested != null) traverseWidgets(nested, formData, exceededInfo, sb, firstBlock);
+            }
+        }
+    }
+
+    private void buildFlatFieldRows(Map<String, Object> formData, Map<String, ExceededFieldInfoDTO> exceededInfo,
+                                     StringBuilder sb) {
+        Set<String> skip = new HashSet<>(EXCLUDED_KEYS);
+        META_KEY_MAP.values().forEach(skip::addAll);
+        for (Map.Entry<String, Object> entry : formData.entrySet()) {
+            if (skip.contains(entry.getKey())) continue;
+            Object val = entry.getValue();
+            if (val == null) continue;
+            appendFieldRow(sb, entry.getKey(), entry.getKey(), val, exceededInfo, null);
+        }
+    }
+
+    private void appendFieldRow(StringBuilder sb, String label, String widgetName, Object value,
+                                 Map<String, ExceededFieldInfoDTO> exceededInfo,
+                                 List<Map<String, Object>> optionItems) {
+        ExceededFieldInfoDTO info = null;
+        if (widgetName != null) info = exceededInfo.get(widgetName);
+        if (info == null && label != null) info = exceededInfo.get(label);
+
+        String alertColor = getAlertColor(info);
+        boolean isAlert = info != null && info.getResult() != null;
+        String displayVal = formatValue(value, optionItems);
+        String rangeText = getValidRange(info);
+
+        sb.append("<tr>")
+          .append("<td style='width:50%;padding:8px 12px;border:1px solid #dde8ed;"
+                  + "font-weight:600;color:#5a6a7a;font-size:12px;'>")
+          .append(escHtml(label != null ? label : widgetName))
+          .append("</td>")
+          .append("<td style='padding:8px 12px;border:1px solid #dde8ed;font-size:13px;color:")
+          .append(alertColor).append(";")
+          .append(isAlert ? "font-weight:bold;" : "")
+          .append("'>")
+          .append(displayVal);
+
+        if (rangeText != null) {
+            sb.append("<div style='font-size:10px;color:#95a5a6;margin-top:3px;font-weight:normal;'>")
+              .append(escHtml(rangeText)).append("</div>");
+        }
+
+        sb.append("</td></tr>");
+    }
+
+    private String buildFooter(Map<String, Object> formData, Long submitterId, String timestamp) {
+        // Try to find a human-readable name in common fields, prioritizing submitter-specific ones
+        String[] potentialNameKeys = {
+            "submitter_name", "submitter", "created_by_name", "operator",
+            "related_inspectors", "qc_personnel", "inspector"
+        };
+        
+        Object submitterName = null;
+        for (String key : potentialNameKeys) {
+            submitterName = findValueRecursive(formData, key);
+            if (submitterName != null && !submitterName.toString().isBlank() && !"-".equals(submitterName.toString())) {
+                break;
+            }
+        }
+
+        String nameStr = (submitterName != null) ? submitterName.toString() : "User #" + submitterId;
+
+        return "<tr><td style='border-top:2px solid #e8f5f8;padding:14px 32px 24px;background:#fafcfc;'>"
+                + "<span style='font-size:12px;color:#7f8c8d;'>Submitter: <strong>" + escHtml(nameStr) + "</strong></span>"
+                + "<span style='color:#bdc3c7;margin:0 8px;'>·</span>"
+                + "<span style='font-size:12px;color:#7f8c8d;'>Submitted at: " + timestamp + "</span>"
+                + "</td></tr>";
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private Object findValueRecursive(Map<String, Object> data, String key) {
+        if (data == null || key == null) return null;
+        if (data.containsKey(key)) return data.get(key);
+        for (Object val : data.values()) {
+            if (val instanceof Map<?, ?> nested) {
+                @SuppressWarnings("unchecked")
+                Object found = findValueRecursive((Map<String, Object>) nested, key);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    private String getAlertColor(ExceededFieldInfoDTO info) {
+        if (info == null) return "#2c3e50";
+        if (info.getResult() == null) return "#27ae60";
+        return switch (info.getResult()) {
+            case "high" -> "#e74c3c";
+            case "low" -> "#2980b9";
+            case "invalid" -> "#e67e22";
+            default -> "#2c3e50";
+        };
+    }
+
+    private String getValidRange(ExceededFieldInfoDTO info) {
+        if (info == null) return null;
+        if ("number".equals(info.getType())) {
+            String min = info.getLowerLimit() != null ? info.getLowerLimit().toPlainString() : "-";
+            String max = info.getUpperLimit() != null ? info.getUpperLimit().toPlainString() : "-";
+            return "Valid range: " + min + " ~ " + max;
+        }
+        if ("options".equals(info.getType())) {
+            List<String> labels = info.getValidOptionLabels();
+            if (labels != null && !labels.isEmpty()) return "Valid options: " + String.join(", ", labels);
+        }
+        return null;
+    }
+
+    private static final Set<String> IMAGE_EXTS = Set.of(
+            "jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "heic", "heif"
+    );
+
+    private String formatValue(Object val, List<Map<String, Object>> optionItems) {
+        if (val == null) return "-";
+
+        if (isUrlValue(val)) {
+            if (val instanceof String s) return formatUrlValue(s);
+            if (val instanceof List<?> list) {
+                return list.stream()
+                        .map(item -> formatUrlValue(item.toString()))
+                        .collect(Collectors.joining(" "));
+            }
+        }
+
+        if (optionItems != null && !optionItems.isEmpty()) {
+            if (val instanceof List<?> list) {
+                return escHtml(list.stream().map(o -> getOptionLabel(o, optionItems)).collect(Collectors.joining(", ")));
+            }
+            return escHtml(getOptionLabel(val, optionItems));
+        }
+
+        if (val instanceof List<?> list) return escHtml(list.stream().map(Object::toString).collect(Collectors.joining(", ")));
+        if (val instanceof Boolean b) return b ? "Yes" : "No";
+        String s = val.toString().trim();
+        return s.isEmpty() ? "-" : escHtml(s);
+    }
+
+    private String formatUrlValue(String url) {
+        if (url == null || url.isBlank()) return "-";
+        boolean isImg = isImageUrl(url);
+        String icon = isImg ? "🖼️ " : "📎 ";
+        String filename = getFilename(url);
+        String bgColor = isImg ? "#f0f9ff" : "#f5f7fa";
+        String borderColor = isImg ? "#bae6fd" : "#dde8ed";
+        String textColor = isImg ? "#0369a1" : "#0085a4";
+
+        return "<a href='" + url + "' target='_blank' style='color:" + textColor + ";text-decoration:none;font-size:12px;"
+                + "display:inline-block;margin:2px;padding:4px 10px;background:" + bgColor + ";border:1px solid " + borderColor + ";border-radius:4px;"
+                + "font-weight:500;box-shadow:0 1px 2px rgba(0,0,0,0.05);'>"
+                + icon + escHtml(filename) + "</a>";
+    }
+
+    private boolean isImageUrl(String url) {
+        if (url == null) return false;
+        String lower = url.toLowerCase();
+        return IMAGE_EXTS.stream().anyMatch(ext -> lower.contains("." + ext));
+    }
+
+    private String getFilename(String url) {
+        if (url == null || url.isBlank()) return "file";
+        int lastSlash = url.lastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < url.length() - 1) {
+            return url.substring(lastSlash + 1);
+        }
+        return "file";
+    }
+
+
+    private String getOptionLabel(Object val, List<Map<String, Object>> optionItems) {
+        if (val == null || optionItems == null) return "-";
+        String s = val.toString().trim();
+        for (Map<String, Object> opt : optionItems) {
+            Object optVal = opt.get("value");
+            if (optVal != null && optVal.toString().trim().equals(s)) {
+                Object label = opt.get("label");
+                return label != null ? label.toString() : s;
+            }
+        }
+        return s;
+    }
+
+    private boolean isUrlValue(Object val) {
+        if (val instanceof String s) return s.startsWith("http") || s.contains("/files/");
+        if (val instanceof List<?> list) return !list.isEmpty() && list.stream().allMatch(
+                item -> item instanceof String str && (str.startsWith("http") || str.contains("/files/")));
+        return false;
+    }
+
+    private String escHtml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+
+    // ─── Mapping helpers ──────────────────────────────────────────────────────
+
+    private FormNotificationConfigDTO toDTO(FormNotificationConfig config, List<FormNotificationRecipient> recipients) {
+        FormNotificationConfigDTO dto = new FormNotificationConfigDTO();
+        dto.setId(config.getId());
+        dto.setFormTemplateId(config.getFormTemplateId());
+        dto.setTriggerType(config.getTriggerType());
+        dto.setDeliveryMethod(config.getDeliveryMethod());
+        dto.setRecipients(recipients.stream().map(r -> {
+            FormNotificationRecipientDTO rd = new FormNotificationRecipientDTO();
+            rd.setUserId(r.getUserId());
+            rd.setUserEmail(r.getUserEmail());
+            rd.setUserName(r.getUserName());
+            return rd;
+        }).collect(Collectors.toList()));
+        return dto;
+    }
+
+    private FormNotificationRecipient toEntity(FormNotificationRecipientDTO dto, Long configId) {
+        FormNotificationRecipient entity = new FormNotificationRecipient();
+        entity.setConfigId(configId);
+        entity.setUserId(dto.getUserId());
+        entity.setUserEmail(dto.getUserEmail());
+        entity.setUserName(dto.getUserName());
+        return entity;
+    }
+}

--- a/src/main/java/com/fps/svmes/services/impl/QcFormTemplateServiceImpl.java
+++ b/src/main/java/com/fps/svmes/services/impl/QcFormTemplateServiceImpl.java
@@ -18,7 +18,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.fps.svmes.models.nosql.FormNode;
 import org.bson.Document;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -685,6 +687,48 @@ public class QcFormTemplateServiceImpl implements QcFormTemplateService {
             default:
                 return "other";
         }
+    }
+
+    @Override
+    public Map<String, Object> duplicateTemplate(Long templateId, String sourceNodeId, Integer requestedBy) {
+        QcFormTemplate original = qcFormTemplateRepository.findById(templateId)
+                .orElseThrow(() -> new RuntimeException("Template not found: " + templateId));
+
+        QcFormTemplateDTO dto = new QcFormTemplateDTO();
+        dto.setName("Copy of " + original.getName());
+        dto.setFormTemplateJson(original.getFormTemplateJson());
+        dto.setApprovalType(original.getApprovalType());
+        dto.setCreatedBy(requestedBy);
+        QcFormTemplateDTO newTemplate = createTemplate(dto);
+
+        FormNode newNode = new FormNode();
+        newNode.setLabel(newTemplate.getName());
+        newNode.setNodeType("document");
+        newNode.setQcFormTemplateId(newTemplate.getId());
+
+        String parentId = formNodeService.findParentNodeId(sourceNodeId).orElse(null);
+        if (parentId == null || "root".equals(parentId)) {
+            formNodeService.saveNode(newNode);
+        } else {
+            formNodeService.addChildNode(parentId, newNode);
+        }
+
+        LocalDate now = LocalDate.now();
+        String yearMonth = now.getYear() + String.format("%02d", now.getMonthValue());
+        String collectionName = "form_template_" + newTemplate.getId() + "_" + yearMonth;
+        mongoService.createCollection(collectionName);
+
+        extractAndStoreKeyLabelPairs(newTemplate);
+        createControlLimitSetting(newTemplate);
+
+        QcFormTemplateEditLog log = new QcFormTemplateEditLog();
+        log.setTemplateId(newTemplate.getId());
+        log.setEditedBy(requestedBy != null ? requestedBy.longValue() : 0L);
+        log.setEditedAt(OffsetDateTime.now());
+        log.setChangeSummary("Duplicated from template " + templateId);
+        editLogRepository.save(log);
+
+        return Map.of("id", newTemplate.getId());
     }
 
     private String findLabelInWidgetList(JsonNode widgetList, String fieldKey) {

--- a/src/main/java/com/fps/svmes/services/impl/QcSummaryEmailExportServiceImpl.java
+++ b/src/main/java/com/fps/svmes/services/impl/QcSummaryEmailExportServiceImpl.java
@@ -1,0 +1,364 @@
+package com.fps.svmes.services.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fps.shared.entity.primary.team.Team;
+import com.fps.svmes.dto.requests.QcSummaryEmailExportRequest;
+import com.fps.svmes.dto.responses.QcSummaryEmailExportResponse;
+import com.fps.svmes.models.sql.production.SuggestedBatch;
+import com.fps.svmes.models.sql.production.SuggestedProduct;
+import com.fps.svmes.models.sql.qcForm.QcFormTemplate;
+import com.fps.svmes.repositories.jpaRepo.production.SuggestedBatchRepository;
+import com.fps.svmes.repositories.jpaRepo.production.SuggestedProductRepository;
+import com.fps.svmes.repositories.jpaRepo.qcForm.QcFormTemplateRepository;
+import com.fps.svmes.repositories.jpaRepo.user.TeamRepository;
+import com.fps.svmes.services.EmailService;
+import com.fps.svmes.services.QcSummaryEmailExportService;
+import com.fps.svmes.services.QcTaskSubmissionLogsService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.HtmlUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QcSummaryEmailExportServiceImpl implements QcSummaryEmailExportService {
+    private static final DateTimeFormatter UTC_DISPLAY_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss 'UTC'");
+
+    private final RestTemplate restTemplate;
+    private final EmailService emailService;
+    private final QcTaskSubmissionLogsService qcTaskSubmissionLogsService;
+    private final ObjectMapper objectMapper;
+    private final TeamRepository teamRepository;
+    private final SuggestedProductRepository suggestedProductRepository;
+    private final SuggestedBatchRepository suggestedBatchRepository;
+    private final QcFormTemplateRepository qcFormTemplateRepository;
+
+    @Value("${qc.snapshot.api.url:http://localhost:8081}")
+    private String qcSnapshotApiUrl;
+
+    @Value("${spring.mail.username:noreply@example.com}")
+    private String fromEmail;
+
+    @Override
+    public QcSummaryEmailExportResponse exportAndSendEmail(QcSummaryEmailExportRequest request, String acceptLanguage) {
+        LinkedHashMap<String, byte[]> attachments = new LinkedHashMap<>();
+        List<Map<String, Object>> documents = List.of();
+        String timestamp = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(ZonedDateTime.now());
+        boolean english = isEnglish(acceptLanguage);
+
+        if (request.getFormats().isPdf() || request.getFormats().isExcel()) {
+            documents = fetchDocumentList(request);
+        }
+
+        if (request.getFormats().isPdf()) {
+            attachments.put("qc_summary_pdf_records_" + timestamp + ".zip",
+                    zipDocuments(documents, document -> qcTaskSubmissionLogsService.exportDocumentToPdf(toDocument(document)), "pdf"));
+        }
+
+        if (request.getFormats().isExcel()) {
+            attachments.put("qc_summary_excel_records_" + timestamp + ".zip",
+                    zipDocuments(documents, document -> qcTaskSubmissionLogsService.exportDocumentToExcel(toDocument(document)), "xlsx"));
+        }
+
+        if (request.getFormats().isAi()) {
+            attachments.put("qc_summary_ai_report_" + timestamp + ".pdf", fetchAiPdf(request, acceptLanguage));
+        }
+
+        String subject = english
+                ? String.format("QC Summary Export %s to %s", request.getStartDate(), request.getEndDate())
+                : String.format("QC汇总导出 %s 至 %s", request.getStartDate(), request.getEndDate());
+        String body = buildEmailBody(request, attachments.keySet().stream().toList(), english);
+
+        emailService.sendHtmlEmailWithAttachments(
+                StringUtils.hasText(fromEmail) ? fromEmail : "noreply@example.com",
+                request.getRecipients(),
+                subject,
+                body,
+                attachments
+        );
+
+        return new QcSummaryEmailExportResponse(
+                english ? "QC summary export email sent successfully." : "QC汇总导出邮件发送成功。",
+                request.getRecipients().size(),
+                new ArrayList<>(attachments.keySet())
+        );
+    }
+
+    private List<Map<String, Object>> fetchDocumentList(QcSummaryEmailExportRequest request) {
+        URI uri = UriComponentsBuilder.fromHttpUrl(qcSnapshotApiUrl)
+                .path("/summary/document-list")
+                .queryParam("start_date", request.getStartDate())
+                .queryParam("end_date", request.getEndDate())
+                .queryParamIfPresent("team_id", Optional.ofNullable(request.getTeamId()))
+                .queryParamIfPresent("shift_id", Optional.ofNullable(request.getShiftId()))
+                .queryParamIfPresent("product_id", Optional.ofNullable(request.getProductId()))
+                .queryParamIfPresent("batch_id", Optional.ofNullable(request.getBatchId()))
+                .queryParamIfPresent("form_template_id", Optional.ofNullable(request.getFormTemplateId()))
+                .build(true)
+                .toUri();
+
+        try {
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    HttpEntity.EMPTY,
+                    new ParameterizedTypeReference<>() {
+                    }
+            );
+            Map<String, Object> body = response.getBody();
+            if (body == null || body.get("data") == null) {
+                throw new IllegalStateException("Snapshot service returned an empty document list response.");
+            }
+            return objectMapper.convertValue(body.get("data"), new TypeReference<List<Map<String, Object>>>() {
+            });
+        } catch (RestClientException e) {
+            throw new RuntimeException("Failed to retrieve document list from snapshot service.", e);
+        }
+    }
+
+    private byte[] fetchAiPdf(QcSummaryEmailExportRequest request, String acceptLanguage) {
+        URI uri = UriComponentsBuilder.fromHttpUrl(qcSnapshotApiUrl)
+                .path("/summary/export-pdf-report")
+                .build(true)
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (StringUtils.hasText(acceptLanguage)) {
+            headers.set(HttpHeaders.ACCEPT_LANGUAGE, acceptLanguage);
+        }
+
+        AiReportPayload payload = new AiReportPayload(
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getTeamId(),
+                request.getShiftId(),
+                request.getProductId(),
+                request.getBatchId(),
+                request.getFormTemplateId(),
+                StringUtils.hasText(request.getTimezone()) ? request.getTimezone() : "UTC",
+                request.getCharts() == null ? Map.of() : request.getCharts()
+        );
+
+        try {
+            ResponseEntity<byte[]> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.POST,
+                    new HttpEntity<>(payload, headers),
+                    byte[].class
+            );
+            byte[] body = response.getBody();
+            if (body == null || body.length == 0) {
+                throw new IllegalStateException("Snapshot service returned an empty AI PDF report.");
+            }
+            return body;
+        } catch (RestClientException e) {
+            throw new RuntimeException("Failed to generate AI PDF report from snapshot service.", e);
+        }
+    }
+
+    private byte[] zipDocuments(List<Map<String, Object>> documents,
+                                Function<Map<String, Object>, byte[]> contentProducer,
+                                String extension) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            for (Map<String, Object> document : documents) {
+                byte[] content = contentProducer.apply(document);
+                ZipEntry entry = new ZipEntry(buildDocumentFilename(document, extension));
+                zipOutputStream.putNextEntry(entry);
+                zipOutputStream.write(content);
+                zipOutputStream.closeEntry();
+            }
+            zipOutputStream.finish();
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create export ZIP attachment.", e);
+        }
+    }
+
+    private Document toDocument(Map<String, Object> rawDocument) {
+        return new Document(objectMapper.convertValue(rawDocument, Map.class));
+    }
+
+    private String buildDocumentFilename(Map<String, Object> document, String extension) {
+        Map<String, Object> uncategorized = asMap(document.get("uncategorized"));
+        String templateName = sanitizeFilename(Objects.toString(uncategorized.get("qc_form_template_name"), "unknown"));
+        Object inspectorsValue = uncategorized.get("related_inspectors");
+        String inspectors;
+        if (inspectorsValue instanceof List<?> list) {
+            inspectors = list.stream().map(String::valueOf).reduce((left, right) -> left + "_" + right).orElse("");
+        } else {
+            inspectors = Objects.toString(inspectorsValue, "");
+        }
+        String safeInspectors = sanitizeFilename(inspectors);
+        String createdAt = formatTimestampForFilename(Objects.toString(document.get("created_at"), null));
+        return templateName + "_" + safeInspectors + "_" + createdAt + "." + extension;
+    }
+
+    private String buildEmailBody(QcSummaryEmailExportRequest request, List<String> attachmentNames, boolean english) {
+        StringBuilder html = new StringBuilder();
+        html.append("<!DOCTYPE html><html><body style=\"font-family: Arial, 'Microsoft YaHei', sans-serif;\">");
+        html.append("<h2>").append(english ? "QC Summary Export" : "QC汇总导出").append("</h2>");
+        html.append("<p>").append(english ? "The requested QC summary export is attached." : "所请求的QC汇总导出已作为附件发送。").append("</p>");
+        html.append("<ul>");
+        html.append("<li>").append(english ? "Date range (UTC)" : "日期范围（UTC）").append(": ")
+                .append(escape(formatUtcDisplay(request.getStartDate()))).append(" ~ ").append(escape(formatUtcDisplay(request.getEndDate()))).append("</li>");
+        html.append("<li>").append(english ? "Filters" : "筛选条件").append(": ")
+                .append(escape(String.join(", ", buildFilterSummary(request, english)))).append("</li>");
+        html.append("<li>").append(english ? "Attachments" : "附件").append(": ")
+                .append(escape(String.join(", ", attachmentNames))).append("</li>");
+        html.append("<li>").append(english ? "Generated at" : "生成时间").append(": ")
+                .append(escape(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z").format(ZonedDateTime.now()))).append("</li>");
+        html.append("</ul>");
+        html.append("</body></html>");
+        return html.toString();
+    }
+
+    private List<String> buildFilterSummary(QcSummaryEmailExportRequest request, boolean english) {
+        List<String> filters = new ArrayList<>();
+        if (request.getTeamId() != null) {
+            String label = teamRepository.findById(request.getTeamId())
+                    .map(Team::getName)
+                    .orElse("ID " + request.getTeamId());
+            filters.add((english ? "Team" : "班组") + ": " + label);
+        }
+        if (request.getShiftId() != null) {
+            filters.add((english ? "Shift" : "班次") + ": ID " + request.getShiftId());
+        }
+        if (request.getProductId() != null) {
+            String label = suggestedProductRepository.findById(request.getProductId().longValue())
+                    .map(SuggestedProduct::getName)
+                    .orElse("ID " + request.getProductId());
+            filters.add((english ? "Product" : "产品") + ": " + label);
+        }
+        if (request.getBatchId() != null) {
+            String label = suggestedBatchRepository.findById(request.getBatchId().longValue())
+                    .map(batch -> StringUtils.hasText(batch.getCode()) ? batch.getCode() : batch.getName())
+                    .orElse("ID " + request.getBatchId());
+            filters.add((english ? "Batch" : "批次") + ": " + label);
+        }
+        if (request.getFormTemplateId() != null) {
+            String label = qcFormTemplateRepository.findById(request.getFormTemplateId())
+                    .map(QcFormTemplate::getName)
+                    .orElse("ID " + request.getFormTemplateId());
+            filters.add((english ? "Form Template" : "表单模板") + ": " + label);
+        }
+        if (filters.isEmpty()) {
+            filters.add(english ? "None" : "无");
+        }
+        return filters;
+    }
+
+    private Map<String, Object> asMap(Object value) {
+        if (value instanceof Map<?, ?> rawMap) {
+            Map<String, Object> map = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+                map.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            return map;
+        }
+        return Map.of();
+    }
+
+    private String formatTimestampForFilename(String createdAt) {
+        if (!StringUtils.hasText(createdAt)) {
+            return "invalid_date";
+        }
+        try {
+            return DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+                    .format(DateTimeFormatter.ISO_DATE_TIME.parse(createdAt));
+        } catch (Exception ignored) {
+            try {
+                return DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+                        .format(ZonedDateTime.parse(createdAt));
+            } catch (Exception ignoredAgain) {
+                return "invalid_date";
+            }
+        }
+    }
+
+    private String formatUtcDisplay(String rawValue) {
+        if (!StringUtils.hasText(rawValue)) {
+            return "";
+        }
+        try {
+            Instant instant = Instant.parse(rawValue);
+            return UTC_DISPLAY_FORMATTER.format(instant.atZone(ZoneOffset.UTC));
+        } catch (Exception ignored) {
+            try {
+                return UTC_DISPLAY_FORMATTER.format(ZonedDateTime.parse(rawValue).withZoneSameInstant(ZoneOffset.UTC));
+            } catch (Exception ignoredAgain) {
+                return rawValue;
+            }
+        }
+    }
+
+    private String sanitizeFilename(String input) {
+        String value = StringUtils.hasText(input) ? input.trim() : "unknown";
+        return value.replaceAll("[\\\\/:*?\"<>|]", "_");
+    }
+
+    private String escape(String value) {
+        return HtmlUtils.htmlEscape(value == null ? "" : value);
+    }
+
+    private boolean isEnglish(String acceptLanguage) {
+        return acceptLanguage != null && acceptLanguage.toLowerCase(Locale.ROOT).startsWith("en");
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class AiReportPayload {
+        @JsonProperty("start_date")
+        private String startDate;
+        @JsonProperty("end_date")
+        private String endDate;
+        @JsonProperty("team_id")
+        private Integer teamId;
+        @JsonProperty("shift_id")
+        private Integer shiftId;
+        @JsonProperty("product_id")
+        private Integer productId;
+        @JsonProperty("batch_id")
+        private Integer batchId;
+        @JsonProperty("form_template_id")
+        private Long formTemplateId;
+        private String timezone;
+        private Map<String, String> charts;
+    }
+}

--- a/src/main/java/com/fps/svmes/services/impl/QcTaskSubmissionLogsServiceImpl.java
+++ b/src/main/java/com/fps/svmes/services/impl/QcTaskSubmissionLogsServiceImpl.java
@@ -496,6 +496,37 @@ public class QcTaskSubmissionLogsServiceImpl implements QcTaskSubmissionLogsServ
     }
 
     @Override
+    public byte[] exportDocumentToExcel(Document document) {
+        try (Workbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("QC Records");
+
+            Map<String, String> flatRow = flattenDocumentForExcel(document);
+            Row headerRow = sheet.createRow(0);
+            Row dataRow = sheet.createRow(1);
+
+            int cellNum = 0;
+            for (Map.Entry<String, String> entry : flatRow.entrySet()) {
+                Cell headerCell = headerRow.createCell(cellNum);
+                headerCell.setCellValue(entry.getKey());
+
+                Cell valueCell = dataRow.createCell(cellNum);
+                valueCell.setCellValue(entry.getValue());
+                cellNum++;
+            }
+
+            for (int i = 0; i < flatRow.size(); i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("Error exporting document to Excel: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
     public byte[] exportDocumentToPdf(Document mongoDocument) {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             // Create a new PDF document (iText)
@@ -687,6 +718,144 @@ public class QcTaskSubmissionLogsServiceImpl implements QcTaskSubmissionLogsServ
         } catch (Exception e) {
             // Fallback: return the original UTC time if parsing fails
             return utcTime;
+        }
+    }
+
+    private Map<String, String> flattenDocumentForExcel(Document document) {
+        Map<String, String> flatRow = new LinkedHashMap<>();
+        Map<String, Object> groupedDetails = parseGroupedDetails(document);
+
+        for (Map.Entry<String, Object> categoryEntry : groupedDetails.entrySet()) {
+            if (!(categoryEntry.getValue() instanceof Map<?, ?> fields)) {
+                continue;
+            }
+
+            for (Map.Entry<?, ?> fieldEntry : fields.entrySet()) {
+                String key = String.valueOf(fieldEntry.getKey());
+                if (shouldSkipExcelField(key)) {
+                    continue;
+                }
+
+                flatRow.put(key, normalizeExcelValue(fieldEntry.getValue()));
+            }
+        }
+
+        Map<String, Object> uncategorized = asMap(groupedDetails.get("uncategorized"));
+        flatRow.put("Related Products", normalizeExcelValue(uncategorized.get("related_products")));
+        flatRow.put("Related Batches", normalizeExcelValue(uncategorized.get("related_batches")));
+        flatRow.put("QC Personnel", normalizeExcelValue(uncategorized.get("related_inspectors")));
+        flatRow.put("Belonging Shift", normalizeExcelValue(uncategorized.get("related_shifts")));
+        flatRow.put("Belonging Team", normalizeExcelValue(uncategorized.get("related_teams")));
+
+        flatRow.put("Submission ID", normalizeExcelValue(document.get("_id")));
+        flatRow.put("Submission Time", convertToLocalTime(Objects.toString(document.get("created_at"), "")));
+        flatRow.put("Submitter", resolveSubmitterName(document.get("created_by")));
+
+        return flatRow;
+    }
+
+    private Map<String, Object> parseGroupedDetails(Document document) {
+        Map<String, Object> groupedDetails = new LinkedHashMap<>();
+        Set<String> skipKeys = Set.of("_id", "created_at", "created_by", "submissionId");
+
+        for (Map.Entry<String, Object> entry : document.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (skipKeys.contains(key)) {
+                continue;
+            }
+
+            if (value instanceof Map<?, ?>) {
+                groupedDetails.put(key, value);
+            } else {
+                Map<String, Object> uncategorized = asMap(groupedDetails.computeIfAbsent("uncategorized", ignored -> new LinkedHashMap<>()));
+                uncategorized.put(key, value);
+            }
+        }
+
+        return groupedDetails;
+    }
+
+    private Map<String, Object> asMap(Object value) {
+        if (value instanceof Map<?, ?> mapValue) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
+                result.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            return result;
+        }
+        return new LinkedHashMap<>();
+    }
+
+    private boolean shouldSkipExcelField(String key) {
+        return "e-signature".equals(key)
+                || "approval_info".equals(key)
+                || key.startsWith("related_")
+                || key.startsWith("qc_form_template")
+                || "version_group_id".equals(key)
+                || "version".equals(key)
+                || "exceeded_info".equals(key);
+    }
+
+    private String normalizeExcelValue(Object value) {
+        if (value == null) {
+            return "-";
+        }
+        if (value instanceof Collection<?> collection) {
+            if (collection.isEmpty()) {
+                return "-";
+            }
+            if (collection.stream().allMatch(this::isUrlLike)) {
+                if (collection.stream().anyMatch(this::isImageUrlLike)) {
+                    return "(See images in application)";
+                }
+                return "(See files in application)";
+            }
+            return collection.stream()
+                    .map(item -> item == null ? "-" : String.valueOf(item))
+                    .collect(Collectors.joining(", "));
+        }
+        String stringValue = String.valueOf(value);
+        return stringValue.isBlank() ? "-" : stringValue;
+    }
+
+    private boolean isUrlLike(Object value) {
+        if (!(value instanceof String stringValue)) {
+            return false;
+        }
+        return stringValue.startsWith("http://")
+                || stringValue.startsWith("https://")
+                || stringValue.contains("/files/");
+    }
+
+    private boolean isImageUrlLike(Object value) {
+        if (!(value instanceof String stringValue)) {
+            return false;
+        }
+        String lower = stringValue.toLowerCase(Locale.ROOT);
+        return lower.contains(".jpg")
+                || lower.contains(".jpeg")
+                || lower.contains(".png")
+                || lower.contains(".gif")
+                || lower.contains(".bmp")
+                || lower.contains(".webp")
+                || lower.contains(".svg")
+                || lower.contains(".ico")
+                || lower.contains(".tiff")
+                || lower.contains(".tif")
+                || lower.contains(".heic")
+                || lower.contains(".heif");
+    }
+
+    private String resolveSubmitterName(Object createdByValue) {
+        if (createdByValue == null) {
+            return "-";
+        }
+        try {
+            String name = userRepository.findNameById(Integer.parseInt(String.valueOf(createdByValue)));
+            return name == null || name.isBlank() ? "-" : name;
+        } catch (Exception e) {
+            return "-";
         }
     }
 

--- a/src/test/java/com/fps/svmes/controllers/QcSummaryEmailExportControllerTest.java
+++ b/src/test/java/com/fps/svmes/controllers/QcSummaryEmailExportControllerTest.java
@@ -1,0 +1,117 @@
+package com.fps.svmes.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fps.svmes.dto.requests.QcSummaryEmailExportRequest;
+import com.fps.svmes.dto.responses.QcSummaryEmailExportResponse;
+import com.fps.svmes.services.QcSummaryEmailExportService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class QcSummaryEmailExportControllerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final StubService service = new StubService();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new QcSummaryEmailExportController(service))
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    void shouldReturn400WhenRecipientsAreMissing() throws Exception {
+        QcSummaryEmailExportRequest request = validRequest();
+        request.setRecipients(List.of());
+
+        mockMvc.perform(post("/export-send-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400WhenNoFormatsAreSelected() throws Exception {
+        QcSummaryEmailExportRequest request = validRequest();
+        request.setFormats(new QcSummaryEmailExportRequest.Formats(false, false, false));
+
+        mockMvc.perform(post("/export-send-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400WhenPayloadIsMalformed() throws Exception {
+        mockMvc.perform(post("/export-send-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"start_date\":"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn500WhenServiceFails() throws Exception {
+        service.runtimeException = new RuntimeException("boom");
+
+        mockMvc.perform(post("/export-send-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Accept-Language", "en-US")
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void shouldReturn200ForValidRequest() throws Exception {
+        service.response = new QcSummaryEmailExportResponse("ok", 1, List.of("file.zip"));
+
+        mockMvc.perform(post("/export-send-email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Accept-Language", "en-US")
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isOk());
+    }
+
+    private QcSummaryEmailExportRequest validRequest() {
+        return new QcSummaryEmailExportRequest(
+                "2026-04-01T00:00:00Z",
+                "2026-04-08T00:00:00Z",
+                1,
+                2,
+                3,
+                4,
+                5L,
+                "America/Los_Angeles",
+                List.of("qc@example.com"),
+                new QcSummaryEmailExportRequest.Formats(true, false, false),
+                Map.of("pass_rate", "data:image/png;base64,abc")
+        );
+    }
+
+    private static class StubService implements QcSummaryEmailExportService {
+        private QcSummaryEmailExportResponse response = new QcSummaryEmailExportResponse("ok", 1, List.of("file.zip"));
+        private RuntimeException runtimeException;
+
+        @Override
+        public QcSummaryEmailExportResponse exportAndSendEmail(QcSummaryEmailExportRequest request, String acceptLanguage) {
+            if (runtimeException != null) {
+                throw runtimeException;
+            }
+            return response;
+        }
+    }
+}

--- a/src/test/java/com/fps/svmes/services/QcSummaryEmailExportServiceImplTest.java
+++ b/src/test/java/com/fps/svmes/services/QcSummaryEmailExportServiceImplTest.java
@@ -1,0 +1,270 @@
+package com.fps.svmes.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fps.svmes.dto.dtos.qcForm.QcTaskSubmissionLogsDTO;
+import com.fps.svmes.dto.requests.QcSummaryEmailExportRequest;
+import com.fps.svmes.dto.responses.QcSummaryEmailExportResponse;
+import com.fps.svmes.services.impl.QcSummaryEmailExportServiceImpl;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QcSummaryEmailExportServiceImplTest {
+
+    private StubRestTemplate restTemplate;
+    private CapturingEmailService emailService;
+    private StubQcTaskSubmissionLogsService logsService;
+    private QcSummaryEmailExportServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new StubRestTemplate();
+        emailService = new CapturingEmailService();
+        logsService = new StubQcTaskSubmissionLogsService();
+        service = new QcSummaryEmailExportServiceImpl(
+                restTemplate,
+                emailService,
+                logsService,
+                new ObjectMapper(),
+                null,
+                null,
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(service, "qcSnapshotApiUrl", "http://snapshot");
+        ReflectionTestUtils.setField(service, "fromEmail", "noreply@example.com");
+    }
+
+    @Test
+    void pdfOnlyShouldSendOneZipAttachment() throws Exception {
+        restTemplate.documentListResponse = sampleDocumentListResponse();
+        logsService.pdfBytes = "pdf-bytes".getBytes();
+
+        QcSummaryEmailExportResponse response = service.exportAndSendEmail(baseRequest(true, false, false), "en-US");
+
+        assertEquals("noreply@example.com", emailService.to);
+        assertEquals(List.of("one@example.com", "two@example.com"), emailService.bccRecipients);
+        assertEquals(1, emailService.attachments.size());
+        assertEquals(List.of("qc_example_Inspector A_20260401_120000.pdf"), zipEntries(emailService.attachments.values().iterator().next()));
+        assertEquals(2, response.getRecipientCount());
+    }
+
+    @Test
+    void excelOnlyShouldSendOneZipAttachment() throws Exception {
+        restTemplate.documentListResponse = sampleDocumentListResponse();
+        logsService.excelBytes = "xlsx-bytes".getBytes();
+
+        service.exportAndSendEmail(baseRequest(false, true, false), "en-US");
+
+        assertEquals(1, emailService.attachments.size());
+        assertEquals(List.of("qc_example_Inspector A_20260401_120000.xlsx"), zipEntries(emailService.attachments.values().iterator().next()));
+    }
+
+    @Test
+    void aiOnlyShouldSendOnePdfAttachment() {
+        restTemplate.aiPdfBytes = "ai-pdf".getBytes();
+
+        service.exportAndSendEmail(baseRequest(false, false, true), "en-US");
+
+        assertEquals(0, restTemplate.getCallCount);
+        assertEquals(1, restTemplate.postCallCount);
+        assertEquals(1, emailService.attachments.size());
+        assertTrue(emailService.attachments.keySet().iterator().next().endsWith(".pdf"));
+        assertArrayEquals("ai-pdf".getBytes(), emailService.attachments.values().iterator().next());
+    }
+
+    @Test
+    void combinedSelectionsShouldAttachAllArtifacts() {
+        restTemplate.documentListResponse = sampleDocumentListResponse();
+        restTemplate.aiPdfBytes = "ai-pdf".getBytes();
+        logsService.pdfBytes = "pdf-bytes".getBytes();
+        logsService.excelBytes = "xlsx-bytes".getBytes();
+
+        service.exportAndSendEmail(baseRequest(true, true, true), "en-US");
+
+        assertEquals(3, emailService.attachments.size());
+        assertEquals(1, restTemplate.getCallCount);
+        assertEquals(1, restTemplate.postCallCount);
+    }
+
+    @Test
+    void shouldPropagateSnapshotFailures() {
+        restTemplate.getException = new RuntimeException("downstream");
+
+        assertThrows(RuntimeException.class, () -> service.exportAndSendEmail(baseRequest(true, false, false), "en-US"));
+    }
+
+    private Map<String, Object> sampleDocumentListResponse() {
+        return Map.of(
+                "data", List.of(Map.of(
+                        "_id", "abc123",
+                        "created_at", "2026-04-01T12:00:00",
+                        "created_by", 7,
+                        "uncategorized", Map.of(
+                                "qc_form_template_name", "qc/example",
+                                "related_inspectors", List.of("Inspector A")
+                        )
+                ))
+        );
+    }
+
+    private QcSummaryEmailExportRequest baseRequest(boolean pdf, boolean excel, boolean ai) {
+        return new QcSummaryEmailExportRequest(
+                "2026-04-01T00:00:00Z",
+                "2026-04-08T00:00:00Z",
+                null,
+                null,
+                null,
+                null,
+                null,
+                "America/Los_Angeles",
+                List.of("one@example.com", "two@example.com"),
+                new QcSummaryEmailExportRequest.Formats(pdf, excel, ai),
+                Map.of("chart", "data:image/png;base64,abc")
+        );
+    }
+
+    private List<String> zipEntries(byte[] zipBytes) throws Exception {
+        try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ArrayList<String> entries = new ArrayList<>();
+            ZipEntry entry;
+            while ((entry = inputStream.getNextEntry()) != null) {
+                entries.add(entry.getName());
+            }
+            return entries;
+        }
+    }
+
+    private static class StubRestTemplate extends RestTemplate {
+        private Map<String, Object> documentListResponse;
+        private byte[] aiPdfBytes;
+        private RuntimeException getException;
+        private RuntimeException postException;
+        private int getCallCount;
+        private int postCallCount;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> ResponseEntity<T> exchange(URI url, HttpMethod method, HttpEntity<?> requestEntity, ParameterizedTypeReference<T> responseType) {
+            getCallCount++;
+            if (getException != null) {
+                throw getException;
+            }
+            return ResponseEntity.ok((T) documentListResponse);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> ResponseEntity<T> exchange(URI url, HttpMethod method, HttpEntity<?> requestEntity, Class<T> responseType) {
+            postCallCount++;
+            if (postException != null) {
+                throw postException;
+            }
+            return ResponseEntity.ok((T) aiPdfBytes);
+        }
+    }
+
+    private static class CapturingEmailService implements EmailService {
+        private String to;
+        private List<String> bccRecipients;
+        private String subject;
+        private String htmlContent;
+        private Map<String, byte[]> attachments = Map.of();
+
+        @Override
+        public void sendHtmlEmail(String to, String subject, String htmlContent) {
+            this.to = to;
+            this.subject = subject;
+            this.htmlContent = htmlContent;
+        }
+
+        @Override
+        public void sendHtmlEmailWithAttachments(String to, List<String> bccRecipients, String subject, String htmlContent, Map<String, byte[]> attachments) {
+            this.to = to;
+            this.bccRecipients = bccRecipients;
+            this.subject = subject;
+            this.htmlContent = htmlContent;
+            this.attachments = attachments;
+        }
+
+        @Override
+        public void sendWeeklyReport(String to, String subject, String htmlContent) {
+            sendHtmlEmail(to, subject, htmlContent);
+        }
+    }
+
+    private static class StubQcTaskSubmissionLogsService implements QcTaskSubmissionLogsService {
+        private byte[] pdfBytes = new byte[0];
+        private byte[] excelBytes = new byte[0];
+
+        @Override
+        public QcTaskSubmissionLogsDTO insertLog(QcTaskSubmissionLogsDTO dto) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<QcTaskSubmissionLogsDTO> getAllByCreatedByAndTaskId(Integer createdBy, Long dispatchedTaskId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Document getDocumentBySubmissionId(String submissionId, Long formId, Integer createdBy, Optional<String> inputCollectionName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Document> getDocumentsByQcFormTemplateIdAndCreatedBy(Long qcFormTemplateId, Integer createdBy) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public byte[] exportDocumentsToExcel(List<Document> documents) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public byte[] exportDocumentToExcel(Document document) {
+            return excelBytes;
+        }
+
+        @Override
+        public byte[] exportDocumentToPdf(Document document) {
+            return pdfBytes;
+        }
+
+        @Override
+        public void deleteSubmissionLog(String submissionId, String collectionName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Document getRawDocumentBySubmissionId(String submissionId, String collectionName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Map<String, Object>> getFormTemplateFieldList(Long formId) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/fps/svmes/services/impl/EmailServiceImplTest.java
+++ b/src/test/java/com/fps/svmes/services/impl/EmailServiceImplTest.java
@@ -1,0 +1,93 @@
+package com.fps.svmes.services.impl;
+
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailServiceImplTest {
+
+    private CapturingMailSender mailSender;
+    private EmailServiceImpl emailService;
+
+    @BeforeEach
+    void setUp() {
+        mailSender = new CapturingMailSender();
+        emailService = new EmailServiceImpl(mailSender);
+        ReflectionTestUtils.setField(emailService, "fromEmail", "noreply@example.com");
+    }
+
+    @Test
+    void sendHtmlEmailWithAttachmentsShouldPopulateVisibleToBccAndAttachments() throws Exception {
+        emailService.sendHtmlEmailWithAttachments(
+                "noreply@example.com",
+                List.of("one@example.com", "two@example.com"),
+                "Subject",
+                "<b>hello</b>",
+                Map.of("report.zip", "zip-bytes".getBytes())
+        );
+
+        MimeMessage sent = mailSender.sentMessage;
+        assertEquals("noreply@example.com", sent.getRecipients(Message.RecipientType.TO)[0].toString());
+        assertEquals(2, sent.getRecipients(Message.RecipientType.BCC).length);
+        Object content = sent.getContent();
+        assertTrue(content instanceof jakarta.mail.Multipart);
+        jakarta.mail.Multipart multipart = (jakarta.mail.Multipart) content;
+        assertEquals(2, multipart.getCount());
+    }
+
+    @Test
+    void sendWeeklyReportShouldKeepExistingBehavior() throws Exception {
+        emailService.sendWeeklyReport("weekly@example.com", "Weekly", "<p>body</p>");
+
+        MimeMessage sent = mailSender.sentMessage;
+        assertEquals("weekly@example.com", sent.getRecipients(Message.RecipientType.TO)[0].toString());
+        assertEquals("Weekly", sent.getSubject());
+    }
+
+    private static class CapturingMailSender extends JavaMailSenderImpl {
+        private MimeMessage sentMessage;
+
+        @Override
+        public MimeMessage createMimeMessage() {
+            return new MimeMessage(Session.getInstance(new Properties()));
+        }
+
+        @Override
+        public MimeMessage createMimeMessage(InputStream contentStream) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void send(MimeMessage mimeMessage) {
+            this.sentMessage = mimeMessage;
+        }
+
+        @Override
+        public void send(MimeMessage... mimeMessages) {
+            this.sentMessage = mimeMessages[0];
+        }
+
+        @Override
+        public void send(SimpleMailMessage simpleMessage) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void send(SimpleMailMessage... simpleMessages) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
…nfig

- Add POST /qc-form-templates/{id}/duplicate to clone a template and its tree node
- Add QC summary email export endpoint (POST /export-send-email) with PDF/Excel/AI generation
- Add form notification config CRUD endpoints and service
- Add findParentNodeId to FormNodeService for tree traversal
- Extend QcTaskSubmissionLogsService with new query methods
- Add email service improvements for export delivery